### PR TITLE
Pass through port/p and mount/m options when using watch.

### DIFF
--- a/lib/codex/cli/index.js
+++ b/lib/codex/cli/index.js
@@ -223,7 +223,11 @@ cli.on('watch', function (args) {
   log.info('');
 
   // simulate a serve call
-  cli.emit('serve', { d: opts.outDir, cwd: args.cwd });
+  cli.emit('serve', {
+    d: opts.outDir, cwd: args.cwd,
+    p: args.p, port: args.port,
+    m: args.m, mount: args.mount
+  });
 
   log.info('Starting watch session...');
 


### PR DESCRIPTION
Tested port, haven't used mount yet but it looked like it was getting left out.
