### PR TITLE
Using `fs.watch` for Windows compatibility.

### DIFF
--- a/lib/codex/cli/index.js
+++ b/lib/codex/cli/index.js
@@ -234,16 +234,16 @@ cli.on('watch', function (args) {
     logObject('error', d.data);
   });
 
-  var files = _.files(opts.dataDir);
-  files = files.concat(_.files(opts.templateDir));
-
-  _.watch(files, function (file) {
+  function rebuild() {
     project.flush();
     project.build(function () {
       log.info('Project rebuilt successfully');
       log.info('Watching...');
     });
-  });
+  }
+
+  fs.watch(opts.dataDir, rebuild);
+  fs.watch(opts.templateDir, rebuild);
 });
 
 function padAfter (str, len) {

--- a/lib/codex/utils/fs.js
+++ b/lib/codex/utils/fs.js
@@ -42,38 +42,3 @@ exports.mkdir = function (_path, mode, callback) {
     callback(null);
   });
 };
-
-var ignore = [ 'node_modules', '.git' ];
-function ignored (file) {
-  return !~ignore.indexOf(file);
-}
-
-var extension = [ '.js' ,'.jade', '.md', '.styl', '.json' ];
-function ext (file) {
-  var ex = path.extname(file);
-  return ~extension.indexOf(ex);
-}
-
-exports.files = function (dir, arr) {
-  arr = arr || [];
-  fs.readdirSync(dir)
-    .filter(ignored)
-    .forEach(function (p) {
-      p = path.join(dir, p);
-      if (fs.statSync(p).isDirectory()){
-        exports.files(p, arr);
-      } else if (ext(p)) {
-        arr.push(p);
-      }
-    });
-  return arr;
-};
-
-exports.watch = function (files, fn) {
-  var options = { intervale: 100 };
-  files.forEach(function (file) {
-    fs.watchFile(file, options, function (c, p) {
-      if (p.mtime < c.mtime) fn(file);
-    });
-  });
-};


### PR DESCRIPTION
Now watches whole directories, not specific files. Allows removal of lots of code from utils/fs.

This code will need testing on Mac. I think I read all the warnings in the <a href="http://nodejs.org/docs/latest/api/fs.html#fs_fs_watch_filename_options_listener">docs for `fs.watch`</a>, and sidestepped them all by watching directories, but it's a significant change.

Works on Windows, at least! :)
