### PR TITLE
enable custom configuration of syntax highlighting

### DIFF
--- a/lib/codex/project.js
+++ b/lib/codex/project.js
@@ -382,3 +382,5 @@ Project.prototype.flush = function () {
   this.groups = {};
   this.files = [];
 };
+
+Project.prototype.LANGUAGES = highlight.LANGUAGES;


### PR DESCRIPTION
For issue 13, to enable custom configuration of highlight.js.

Dave
